### PR TITLE
Fix syntax error in core/scanner.py f-string formatting

### DIFF
--- a/PLATFORM/core/scanner.py
+++ b/PLATFORM/core/scanner.py
@@ -208,13 +208,9 @@ class BaseScanner:
         results["duration"] = time.time() - results["start_time"]
 
         self.logger.info(
-            f"Directory scan complete: {
-                results['scanned']} files scanned, "
-            f"{
-                results['skipped']} files skipped, "
-            f"{
-                results['matched']} matches found in {
-                    results['duration']:.2f} seconds"
+            f"Directory scan complete: {results['scanned']} files scanned, "
+            f"{results['skipped']} files skipped, "
+            f"{results['matched']} matches found in {results['duration']:.2f} seconds"
         )
 
         return results


### PR DESCRIPTION
Resolves EOL while scanning string literal error at line 207 by properly formatting multi-line f-string concatenation.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)