### PR TITLE
fix: correct f-string syntax error in tutorial_system.py

### DIFF
--- a/tutorial_system.py
+++ b/tutorial_system.py
@@ -188,11 +188,7 @@ class TutorialManager:
                     if tutorial["id"] in self.user_progress["tutorials_completed"]
                     else "📝 Available"
                 )
-                print(
-                    f"{i}. {
-                        tutorial['title']} ({
-                        tutorial['duration']}) - {status}"
-                )
+                print(f"{i}. {tutorial['title']} ({tutorial['duration']}) - {status}")
             print("0. Return to main menu")
 
             choice = input("Select a tutorial: ").strip()


### PR DESCRIPTION
Fixes #16

Fixed syntax error in tutorial_system.py at line 192 where an f-string was incorrectly split across multiple lines, causing "EOL while scanning string literal" error.

**Changes:**
- Replaced multi-line f-string with single line format
- Resolves Python syntax error and allows job to complete successfully

Generated with [Claude Code](https://claude.ai/code)