### PR TITLE
fix: resolve f-string syntax error in tutorial_system.py

### DIFF
--- a/tutorial_system.py
+++ b/tutorial_system.py
@@ -797,10 +797,7 @@ Total XP: {self.user_progress['experience_points']}
             self.console.print(panel)
         else:
             print(
-                f"\n🎉 ACHIEVEMENT UNLOCKED: {
-                    info.get(
-                        'title',
-                        'Unknown Achievement')}"
+                f"\n🎉 ACHIEVEMENT UNLOCKED: {info.get('title', 'Unknown Achievement')}"
             )
             print(info.get("description", "Great job!"))
             print(f"Bonus XP: +{xp_bonus}")


### PR DESCRIPTION
Fix EOL while scanning string literal error in show_achievement() method by converting multi-line f-string expression to single-line format.

Fixes #18

