### PR TITLE
Fix SyntaxError in core/scanner.py: resolve EOL while scanning string literal

### DIFF
--- a/PLATFORM/core/scanner.py
+++ b/PLATFORM/core/scanner.py
@@ -118,15 +118,11 @@ class BaseScanner:
                 add_result = self.db_manager.add_alert(file_metadata, scan_result)
                 if add_result:
                     self.logger.info(
-                        f"Added alert to database for file: {
-                            file_metadata.get(
-                                'name', '')}"
+                        f"Added alert to database for file: {file_metadata.get('name', '')}"
                     )
                 else:
                     self.logger.error(
-                        f"Failed to add alert to database for file: {
-                            file_metadata.get(
-                                'name', '')}"
+                        f"Failed to add alert to database for file: {file_metadata.get('name', '')}"
                     )
             except Exception as e:
                 self.logger.error(f"Exception adding alert to database: {e}")
@@ -338,9 +334,7 @@ class MultiThreadScanner(BaseScanner):
 
             self.running = True
             self.logger.info(
-                f"Started monitoring directory with {
-                    self.num_threads} threads: {
-                    self.extract_dir}"
+                f"Started monitoring directory with {self.num_threads} threads: {self.extract_dir}"
             )
 
             # Queue existing files for scanning
@@ -444,8 +438,7 @@ class MultiThreadScanner(BaseScanner):
                     self.scan_file(file_path)
                 except Exception as e:
                     self.logger.error(
-                        f"Thread {thread_id} error scanning {file_path}: {
-                            str(e)}"
+                        f"Thread {thread_id} error scanning {file_path}: {str(e)}"
                     )
 
                 # Mark task as done


### PR DESCRIPTION
Fixes #20

Resolved SyntaxError in PLATFORM/core/scanner.py that was causing "EOL while scanning string literal" errors.

## Changes Made
- Fixed f-strings with line breaks inside curly braces in multiple locations
- Lines 121-124: database alert logging 
- Lines 127-130: database error logging
- Lines 341-344: multi-threaded monitoring logging
- Lines 447-449: thread error logging

All f-strings now properly formatted without line breaks inside expressions.

Generated with [Claude Code](https://claude.ai/code)