### PR TITLE
fix: pin anyio dependency to resolve ConnectedUDPSocket ImportError

### DIFF
--- a/EDUCATION/requirements.txt
+++ b/EDUCATION/requirements.txt
@@ -4,6 +4,9 @@
 fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
 
+# Async framework (pin to avoid ConnectedUDPSocket ImportError)
+anyio>=3.6.0,<4.0.0
+
 # Template Engine
 jinja2>=3.1.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ click>=8.0.0,<9.0.0
 requests>=2.25.0
 markdown>=3.3.0
 
+# Async framework (pin to avoid ConnectedUDPSocket ImportError in anyio 4.0+)
+anyio>=3.6.0,<4.0.0
+
 # Testing
 pytest>=7.0.0
 pytest-cov>=3.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ pytest-cov>=4.0.0
 pytest-xdist>=3.0.0
 pytest-benchmark>=3.4.1
 pytest-html>=3.1.0
+pytest-anyio>=0.6.0
 black>=22.0.0
 isort>=5.10.0
 flake8>=4.0.0


### PR DESCRIPTION
Fixes #36

Resolves ImportError: cannot import name 'ConnectedUDPSocket' from 'anyio.abc' by pinning anyio to version <4.0.

## Changes
- Pin anyio to version <4.0 (anyio>=3.6.0,<4.0.0) in requirements.txt and EDUCATION/requirements.txt
- Add pytest-anyio>=0.6.0 to test-requirements.txt for async test compatibility
- Ensures FastAPI async functionality works while maintaining CI test compatibility

## Testing
-  [ ] No ImportError when running test suite
-  [ ] All tests pass in fresh virtual environment
-  [ ] CI pipeline runs without dependency errors

Generated with [Claude Code](https://claude.ai/code)