### PR TITLE
fix: Add db_manager attribute to AlertCorrelator class

### DIFF
--- a/suricata/alert_correlation/correlator.py
+++ b/suricata/alert_correlation/correlator.py
@@ -1,5 +1,6 @@
 """Alert Correlator implementation"""
 from typing import Dict, List, Any
+from .base import AlertDatabaseManager
 
 class AlertCorrelator:
     """Mock Alert Correlator for testing"""
@@ -7,6 +8,10 @@ class AlertCorrelator:
     def __init__(self, config: Dict[str, Any] = None):
         self.config = config or {}
         self.alerts = []
+        
+        # Initialize database manager for correlation storage
+        db_file = config.get("SURICATA_DB_FILE", "logs/alerts.db") if config else "logs/alerts.db"
+        self.db_manager = AlertDatabaseManager(db_file)
     
     def add_alert(self, alert: Dict[str, Any]) -> None:
         """Add an alert"""


### PR DESCRIPTION
Fixes AttributeError in integration test where AlertCorrelator was missing db_manager attribute.

## Changes
- Added AlertDatabaseManager import and initialization to AlertCorrelator
- Follows pattern established in AlertOrchestrator class
- Resolves test_suricata_integration.py:335 failure

Fixes #38

Generated with [Claude Code](https://claude.ai/code)