### PR TITLE
Add async test cases leveraging pytest-asyncio

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = --strict-markers --maxfail=10 --tb=short --disable-warnings
+asyncio_mode = auto
 markers =
     unit: mark a test as a unit test
     integration: mark a test as an integration test
@@ -13,3 +14,4 @@ markers =
     yara: mark a test related to YARA utilities
     suricata: mark a test related to Suricata integration
     ci: mark a test as a CI workflow validation test
+    asyncio: mark a test as an async test using pytest-asyncio

--- a/tests/test_api_async.py
+++ b/tests/test_api_async.py
@@ -1,0 +1,440 @@
+"""
+Async test cases for FastAPI endpoints using pytest-asyncio
+"""
+
+import json
+import os
+import tempfile
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from unittest.mock import Mock, patch, AsyncMock
+
+# Import the FastAPI app and components
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "PLATFORM")))
+
+from api.api_server import app
+from core.database import DatabaseManager
+from core.scanner import SingleThreadScanner
+
+
+@pytest.fixture
+def client():
+    """Test client fixture"""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_config():
+    """Mock configuration fixture"""
+    temp_dir = tempfile.mkdtemp()
+    return {
+        "EXTRACT_DIR": os.path.join(temp_dir, "extracted_files"),
+        "DB_FILE": os.path.join(temp_dir, "test.db"),
+        "RULES_DIR": os.path.join(temp_dir, "rules"),
+        "RULES_INDEX": os.path.join(temp_dir, "rules.index"),
+        "MAX_FILE_SIZE": 1024 * 1024,
+        "SCAN_TIMEOUT": 10,
+        "THREADS": 2,
+        "API_KEY": "test-api-key"
+    }
+
+
+@pytest.fixture
+def mock_db_manager():
+    """Mock database manager fixture"""
+    mock_db = Mock(spec=DatabaseManager)
+    mock_db.get_alerts.return_value = [
+        {
+            "id": 1,
+            "timestamp": "2025-08-03T06:00:00",
+            "file_path": "/test/file.txt",
+            "file_name": "file.txt",
+            "file_size": 1024,
+            "file_type": "text/plain",
+            "md5": "abc123",
+            "sha256": "def456",
+            "zeek_uid": "uid123",
+            "rule_name": "test_rule",
+            "rule_namespace": "default",
+            "rule_meta": '{"author": "test"}',
+            "strings_matched": '["test_string"]',
+            "severity": 5
+        }
+    ]
+    return mock_db
+
+
+class TestAsyncAPIEndpoints:
+    """Test class for async API endpoints"""
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_root_endpoint(self, client):
+        """Test async access to root endpoint"""
+        response = client.get("/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Zeek-YARA Integration API"
+        assert data["version"] == "1.0.0"
+        assert "documentation" in data
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_status_endpoint_with_mocked_components(self, client, mock_config, mock_db_manager):
+        """Test async status endpoint with mocked components"""
+        with patch('api.api_server.config', mock_config), \
+             patch('api.api_server.db_manager', mock_db_manager), \
+             patch('api.api_server.rule_manager') as mock_rule_manager, \
+             patch('api.api_server.suricata_runner') as mock_suricata:
+            
+            # Setup mocks
+            mock_rule_manager.get_rule_list.return_value = ["rule1", "rule2"]
+            mock_suricata.get_status.return_value = {
+                "running": True,
+                "version": "7.0.0",
+                "alert_count": 5,
+                "rules_count": 10
+            }
+            
+            # Create extract directory for the test
+            os.makedirs(mock_config["EXTRACT_DIR"], exist_ok=True)
+            
+            # Make request
+            response = client.get("/status", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["status"] == "operational"
+            assert "uptime" in data
+            assert data["scanner_running"] is False
+            assert data["rules_count"] == 2
+            assert data["alerts_count"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_alerts_endpoint_with_mocked_data(self, client, mock_db_manager):
+        """Test async alerts endpoint with mocked data"""
+        with patch('api.api_server.db_manager', mock_db_manager):
+            response = client.get("/alerts?page=1&page_size=10", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert "alerts" in data
+            assert data["count"] == 1
+            assert data["total"] == 1
+            assert data["page"] == 1
+            assert data["page_size"] == 10
+            
+            # Check alert structure
+            alert = data["alerts"][0]
+            assert alert["id"] == 1
+            assert alert["file_name"] == "file.txt"
+            assert alert["rule_name"] == "test_rule"
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_alerts_endpoint_with_filters(self, client, mock_db_manager):
+        """Test async alerts endpoint with query filters"""
+        with patch('api.api_server.db_manager', mock_db_manager):
+            # Test with severity filter
+            response = client.get("/alerts?severity=5", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            # Test with rule name filter
+            response = client.get("/alerts?rule_name=test", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            # Test with file type filter
+            response = client.get("/alerts?file_type=text", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_specific_alert_endpoint(self, client, mock_db_manager):
+        """Test async access to specific alert by ID"""
+        with patch('api.api_server.db_manager', mock_db_manager):
+            response = client.get("/alerts/1", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["id"] == 1
+            assert data["file_name"] == "file.txt"
+            assert data["rule_name"] == "test_rule"
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_specific_alert_not_found(self, client, mock_db_manager):
+        """Test async access to non-existent alert"""
+        with patch('api.api_server.db_manager', mock_db_manager):
+            response = client.get("/alerts/999", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_scan_endpoint_file_not_found(self, client):
+        """Test async scan endpoint with non-existent file"""
+        scan_data = {"file_path": "/nonexistent/file.txt", "recursive": False}
+        response = client.post("/scan", 
+                             json=scan_data,
+                             headers={"X-API-Key": "test-api-key"})
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_scan_endpoint_with_temp_file(self, client, mock_config):
+        """Test async scan endpoint with temporary file"""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+            tmp_file.write("test content")
+            tmp_file_path = tmp_file.name
+        
+        try:
+            with patch('api.api_server.config', mock_config), \
+                 patch('api.api_server.scanner') as mock_scanner:
+                
+                # Setup mock scanner
+                mock_scanner_instance = Mock(spec=SingleThreadScanner)
+                mock_scanner_instance.scan_file.return_value = {
+                    "matched": False,
+                    "error": None
+                }
+                mock_scanner = mock_scanner_instance
+                
+                # Mock db_manager to return empty results
+                with patch('api.api_server.db_manager') as mock_db:
+                    mock_db.get_alerts.return_value = []
+                    
+                    scan_data = {"file_path": tmp_file_path, "recursive": False}
+                    response = client.post("/scan", 
+                                         json=scan_data,
+                                         headers={"X-API-Key": "test-api-key"})
+                    assert response.status_code == 200
+                    
+                    data = response.json()
+                    assert data["success"] is True
+                    assert "scan_time" in data
+                    assert data["scanned_files"] == 1
+        finally:
+            os.unlink(tmp_file_path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_scanner_start_endpoint(self, client, mock_config):
+        """Test async scanner start endpoint"""
+        with patch('api.api_server.config', mock_config), \
+             patch('api.api_server.SingleThreadScanner') as mock_scanner_class:
+            
+            mock_scanner = Mock()
+            mock_scanner.start_monitoring.return_value = True
+            mock_scanner_class.return_value = mock_scanner
+            
+            response = client.post("/scanner/start?threads=0", 
+                                 headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["success"] is True
+            assert data["scanner_type"] == "Single-threaded"
+            assert data["threads"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_scanner_stop_endpoint(self, client):
+        """Test async scanner stop endpoint"""
+        with patch('api.api_server.scanner') as mock_scanner:
+            mock_scanner.running = True
+            mock_scanner.stop_monitoring.return_value = True
+            
+            response = client.post("/scanner/stop", 
+                                 headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["success"] is True
+            assert data["status"] == "stopped"
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_rules_update_endpoint(self, client):
+        """Test async rules update endpoint"""
+        with patch('api.api_server.rule_manager') as mock_rule_manager:
+            mock_rule_manager.compile_rules.return_value = True
+            mock_rule_manager.get_rule_list.return_value = ["rule1", "rule2"]
+            
+            response = client.post("/rules/update", 
+                                 headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["success"] is True
+            assert data["rule_count"] == 2
+            assert data["status"] == "updated"
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_rules_get_endpoint(self, client):
+        """Test async rules list endpoint"""
+        with patch('api.api_server.rule_manager') as mock_rule_manager:
+            mock_rules = [
+                {"name": "test_rule", "namespace": "default", "tags": ["test"], "meta": {"author": "test"}},
+                {"name": "malware_rule", "namespace": "malware", "tags": ["malware"], "meta": {"severity": "high"}}
+            ]
+            mock_rule_manager.get_rule_list.return_value = mock_rules
+            
+            response = client.get("/rules", headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert "rules" in data
+            assert data["count"] == 2
+            assert len(data["rules"]) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_api_key_authentication(self, client):
+        """Test async API key authentication"""
+        # Test without API key
+        response = client.get("/status")
+        assert response.status_code == 401
+        
+        # Test with wrong API key
+        response = client.get("/status", headers={"X-API-Key": "wrong-key"})
+        assert response.status_code == 401
+        
+        # Test with correct API key (mocked)
+        with patch('api.api_server.API_KEY', 'test-api-key'):
+            response = client.get("/status", headers={"X-API-Key": "test-api-key"})
+            # This may still fail due to other dependencies, but auth should pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_webhook_config_endpoint(self, client):
+        """Test async webhook configuration endpoint"""
+        webhook_config = {
+            "url": "https://example.com/webhook",
+            "secret": "webhook-secret",
+            "events": ["alert", "scan"],
+            "enabled": True
+        }
+        
+        with patch('builtins.open'), \
+             patch('json.dump'):
+            
+            response = client.post("/webhook/config", 
+                                 json=webhook_config,
+                                 headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["success"] is True
+            assert "webhook" in data
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_webhook_get_config_endpoint(self, client):
+        """Test async webhook get configuration endpoint"""
+        with patch('os.path.exists', return_value=False):
+            response = client.get("/webhook/config", 
+                                headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["configured"] is False
+            assert data["webhook"] is None
+
+
+class TestAsyncPerformance:
+    """Performance tests for async endpoints"""
+
+    @pytest.mark.asyncio
+    @pytest.mark.performance
+    async def test_concurrent_status_requests(self, client):
+        """Test concurrent async requests to status endpoint"""
+        import asyncio
+        from concurrent.futures import ThreadPoolExecutor
+        
+        def make_request():
+            with patch('api.api_server.API_KEY', ''):  # Disable auth for test
+                return client.get("/status")
+        
+        # Test concurrent requests
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            loop = asyncio.get_event_loop()
+            futures = [
+                loop.run_in_executor(executor, make_request)
+                for _ in range(10)
+            ]
+            responses = await asyncio.gather(*futures)
+        
+        # All requests should succeed
+        for response in responses:
+            assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.performance
+    async def test_alerts_endpoint_performance(self, client, mock_db_manager):
+        """Test async alerts endpoint performance with large dataset"""
+        # Mock large dataset
+        large_dataset = []
+        for i in range(1000):
+            large_dataset.append({
+                "id": i,
+                "timestamp": f"2025-08-03T06:{i%60:02d}:00",
+                "file_path": f"/test/file_{i}.txt",
+                "file_name": f"file_{i}.txt",
+                "file_size": 1024 + i,
+                "file_type": "text/plain",
+                "md5": f"abc{i}",
+                "sha256": f"def{i}",
+                "zeek_uid": f"uid{i}",
+                "rule_name": f"test_rule_{i%10}",
+                "rule_namespace": "default",
+                "rule_meta": '{"author": "test"}',
+                "strings_matched": '["test_string"]',
+                "severity": i % 10
+            })
+        
+        mock_db_manager.get_alerts.return_value = large_dataset
+        
+        with patch('api.api_server.db_manager', mock_db_manager):
+            response = client.get("/alerts?page=1&page_size=50", 
+                                headers={"X-API-Key": "test-api-key"})
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert data["count"] == 50  # Page size
+            assert data["total"] == 1000  # Total records
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_async_endpoint_error_handling():
+    """Test async error handling in endpoints"""
+    client = TestClient(app)
+    
+    # Test with malformed JSON in scan request
+    response = client.post("/scan", 
+                         data="invalid json",
+                         headers={"X-API-Key": "test-api-key",
+                                "Content-Type": "application/json"})
+    assert response.status_code == 422  # Unprocessable Entity
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_async_verify_api_key_function():
+    """Test async API key verification function"""
+    from api.api_server import verify_api_key
+    
+    # Test valid key
+    with patch('api.api_server.API_KEY', 'test-key'):
+        result = await verify_api_key('test-key')
+        assert result is True
+    
+    # Test invalid key - should raise HTTPException
+    with patch('api.api_server.API_KEY', 'test-key'):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_api_key('wrong-key')
+        assert exc_info.value.status_code == 401

--- a/tests/test_async_examples.py
+++ b/tests/test_async_examples.py
@@ -1,0 +1,138 @@
+"""
+Simple async test examples demonstrating pytest-asyncio usage
+This file shows the basic pattern requested in the GitHub issue
+"""
+
+import pytest
+import asyncio
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+# Import the FastAPI app
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "PLATFORM")))
+
+from api.api_server import app
+
+
+@pytest.mark.asyncio
+async def test_api_endpoint():
+    """Test async FastAPI endpoints - basic example as requested"""
+    client = TestClient(app)
+    
+    # Test the root endpoint
+    response = client.get("/")
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert "name" in data
+    assert "version" in data
+
+
+@pytest.mark.asyncio
+async def test_status_endpoint():
+    """Test async status endpoint"""
+    client = TestClient(app)
+    
+    # Disable API key auth for this test
+    with patch('api.api_server.API_KEY', ''):
+        response = client.get("/status")
+        assert response.status_code == 200
+        
+        data = response.json()
+        assert "status" in data
+        assert "uptime" in data
+
+
+@pytest.mark.asyncio
+async def test_concurrent_api_calls():
+    """Test multiple concurrent async API calls"""
+    client = TestClient(app)
+    
+    async def make_api_call():
+        """Helper function to make an API call"""
+        return client.get("/")
+    
+    # Make multiple concurrent requests
+    tasks = [make_api_call() for _ in range(5)]
+    responses = await asyncio.gather(*tasks)
+    
+    # Verify all responses
+    for response in responses:
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Zeek-YARA Integration API"
+
+
+@pytest.mark.asyncio
+async def test_alerts_endpoint_basic():
+    """Test async alerts endpoint - basic usage"""
+    client = TestClient(app)
+    
+    # Mock the database to avoid dependencies
+    with patch('api.api_server.db_manager') as mock_db:
+        mock_db.get_alerts.return_value = []
+        
+        # Disable API key for test
+        with patch('api.api_server.API_KEY', ''):
+            response = client.get("/alerts")
+            assert response.status_code == 200
+            
+            data = response.json()
+            assert "alerts" in data
+            assert isinstance(data["alerts"], list)
+
+
+@pytest.mark.asyncio
+async def test_async_exception_handling():
+    """Test async exception handling in API calls"""
+    client = TestClient(app)
+    
+    # Test accessing non-existent endpoint
+    response = client.get("/nonexistent")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/", "/docs", "/openapi.json"])
+async def test_multiple_endpoints_async(endpoint):
+    """Test multiple endpoints using async and parametrize"""
+    client = TestClient(app)
+    
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_async_with_timeout():
+    """Test async API calls with timeout"""
+    client = TestClient(app)
+    
+    # Use asyncio.wait_for to test with timeout
+    try:
+        response = await asyncio.wait_for(
+            asyncio.to_thread(client.get, "/"),
+            timeout=5.0
+        )
+        assert response.status_code == 200
+    except asyncio.TimeoutError:
+        pytest.fail("API call timed out")
+
+
+@pytest.mark.asyncio
+async def test_async_setup_and_teardown():
+    """Test async setup and teardown patterns"""
+    # Async setup
+    setup_data = await asyncio.sleep(0.1, result="setup_complete")
+    assert setup_data == "setup_complete"
+    
+    try:
+        # Test the actual functionality
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
+    finally:
+        # Async teardown
+        teardown_data = await asyncio.sleep(0.1, result="teardown_complete")
+        assert teardown_data == "teardown_complete"


### PR DESCRIPTION
Implements comprehensive async test cases for FastAPI endpoints using pytest-asyncio.

## Changes
- Created test_async_examples.py with basic async test patterns
- Created test_api_async.py with comprehensive FastAPI endpoint tests
- Updated pytest.ini with asyncio configuration
- Added performance tests for concurrent async requests
- Includes proper mocking and error handling

Fixes #49

Generated with [Claude Code](https://claude.ai/code)