### PR TITLE
Fix grep test for cross-platform compatibility

### DIFF
--- a/tests/ci_tests/test_educational_content_job.py
+++ b/tests/ci_tests/test_educational_content_job.py
@@ -117,7 +117,8 @@ class TestEducationalContentJob:
             text=True
         )
         
-        assert result.returncode == 0, "grep should be available"
+        # Platform-specific behavior: Linux grep --help returns 0, macOS returns 2
+        assert result.returncode in [0, 2], "grep should be available"
 
     def test_pythonpath_for_educational_tests(self):
         """Test PYTHONPATH configuration for educational tests."""


### PR DESCRIPTION
Update test_grep_command_for_links to accept both exit codes 0 (Linux) and 2 (macOS) for grep --help command. Add explanatory comment about platform-specific behavior.

Fixes #57

Generated with [Claude Code](https://claude.ai/code)