### PR TITLE
docs: Make Python 3.12.5 requirement more prominent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,9 @@ Remember that this project serves educational purposes. All contributions should
 ### Prerequisites
 
 Before contributing, ensure you have:
+- **Python Version**: **Python 3.12.5 or higher** (Required for consistent test execution and compatibility)
 - **Technical Skills**: Basic understanding of Python, network security concepts, or documentation writing
-- **Development Environment**: Python 3.8+, Git, and a text editor
+- **Development Environment**: Git and a text editor
 - **Learning Mindset**: Willingness to learn and help others learn
 
 ### First Steps
@@ -137,6 +138,13 @@ git remote add upstream https://github.com/ORIGINAL_REPO/zeek_yara_integration.g
 ### 2. Environment Setup
 
 ```bash
+# Verify Python version (must be 3.12.5 or higher)
+python3 --version  # Should output: Python 3.12.5 or higher
+
+# If you need to install Python 3.12.5:
+# pyenv install 3.12.5
+# pyenv local 3.12.5
+
 # Create virtual environment
 python3 -m venv venv
 source venv/bin/activate  # On Windows: venv\\Scripts\\activate

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ An educational platform that teaches network security monitoring, threat detecti
 
 ## Quick Start
 
+**⚠️ Prerequisites: Requires Python 3.12.5 or higher**
+
 **Starting points**:
 1. [EICAR Demo](docs/examples/quick-demos/eicar-detection.md) - Threat detection demonstration
 2. [Getting Started Tutorial](docs/tutorials/getting-started.md) - Setup and first steps
@@ -47,10 +49,12 @@ An educational platform that teaches network security monitoring, threat detecti
 - **Learning Tracks**: Structured progression paths
 - **Research Platform**: Extensible architecture for experimentation
 
-## Prerequisites
+## Requirements
+
+**⚠️ Important: Python Version Requirement**
+- **Python 3.12.5 or higher** (Required for consistent test execution and compatibility)
 
 **System Requirements**:
-- Python 3.8+
 - Zeek (latest stable release)
 - YARA 4.2.0+
 - Suricata 6.0.0+
@@ -74,6 +78,9 @@ requests>=2.28.0
 ### Clone and Setup
 
 ```bash
+# Verify Python version (must be 3.12.5 or higher)
+python3 --version  # Should output: Python 3.12.5 or higher
+
 # Clone the repository
 git clone https://github.com/quanticsoul4772/zeek-yara-integration.git
 cd zeek-yara-integration
@@ -124,6 +131,13 @@ python start_tutorial_server.py
 - Tests pass
 
 **Troubleshooting**:
+- **Wrong Python version**: Install Python 3.12.5 using pyenv:
+  ```bash
+  # Install pyenv (see: https://github.com/pyenv/pyenv#installation)
+  pyenv install 3.12.5
+  pyenv local 3.12.5
+  python3 --version  # Verify version
+  ```
 - CLI tool fails: Check Python path and virtual environment activation
 - Platform status shows missing components: Verify all directories exist
 - Demo fails: Check temporary directory permissions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zeek-yara-integration"
+description = "Educational network security platform integrating Zeek, YARA, and Suricata"
+requires-python = ">=3.12.5"
+dynamic = ["version"]
+
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py312']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
Make the Python 3.12.5 requirement more prominent in documentation to prevent setup issues for new developers.

## Changes
- Add Python version warning to README.md Quick Start section
- Update Prerequisites section with clear version requirement
- Add Python version verification to installation instructions
- Include pyenv installation guide in troubleshooting
- Update CONTRIBUTING.md with Python 3.12.5 requirement
- Add pyproject.toml with requires-python specification
- Update Black target version to py312

Fixes #59

Generated with [Claude Code](https://claude.ai/code)