### PR TITLE
fix: separate production and development dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+# Core production dependencies for Zeek-YARA Integration Platform
+# Network security monitoring toolkit runtime requirements
+
 # Core dependencies
 click>=8.0.0,<9.0.0
-requests>=2.25.0
+requests>=2.28.0
 markdown>=3.3.0
 yara-python>=4.2.0
 watchdog>=2.1.0
@@ -9,28 +12,3 @@ PyYAML>=6.0
 
 # Async framework (pin to avoid ConnectedUDPSocket ImportError in anyio 4.0+)
 anyio>=3.6.0,<4.0.0
-
-# Testing
-pytest>=7.0.0
-pytest-cov>=3.0.0
-pytest-xdist>=2.5.0
-pytest-benchmark>=3.4.0
-pytest-html>=3.1.0
-pytest-metadata>=1.11.0
-
-# Code quality
-black>=22.0.0,<24.0.0
-isort>=5.10.0
-flake8>=4.0.0
-mypy>=0.910
-autopep8>=1.6.0
-autoflake>=1.4
-
-# Security
-bandit>=1.7.0
-safety>=2.0.0
-
-# Documentation
-mkdocs>=1.2.0
-mkdocs-material>=8.0.0
-mkdocs-mermaid2-plugin>=0.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,24 +1,32 @@
+# Development and testing dependencies for Zeek-YARA Integration Platform
+# These dependencies are NOT required for production runtime
+
+# Testing framework
 pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-xdist>=3.0.0
 pytest-benchmark>=3.4.1
 pytest-html>=3.1.0
 pytest-asyncio>=0.21.0
+pytest-metadata>=1.11.0
+
+# Testing utilities
 httpx>=0.24.0
-black>=22.0.0
+memory-profiler>=0.60.0
+
+# Code quality and formatting
+black>=22.0.0,<24.0.0
 isort>=5.10.0
 flake8>=4.0.0
 mypy>=0.990
+autopep8>=1.6.0
+autoflake>=1.4
+
+# Security analysis
 bandit>=1.7.0
 safety>=2.3.0
-memory-profiler>=0.60.0
+
+# Documentation
 mkdocs>=1.4.0
 mkdocs-material>=8.5.0
 mkdocs-mermaid2-plugin>=0.6.0
-click>=8.0.0
-requests>=2.28.0
-markdown>=3.3.0
-yara-python>=4.2.0
-watchdog>=2.1.0
-netifaces>=0.11.0
-PyYAML>=6.0


### PR DESCRIPTION
Fixes dependency duplication between requirements.txt and test-requirements.txt

## Changes
- Moved production runtime dependencies to requirements.txt only
- Moved testing/development tools to test-requirements.txt only
- Removed duplication of core dependencies
- Resolved version conflicts
- Added clear documentation headers

Fixes #63

Generated with [Claude Code](https://claude.ai/code)