### PR TITLE
Add test coverage enhancements for py.typed files and import performance

### DIFF
--- a/tests/performance_tests/test_performance.py
+++ b/tests/performance_tests/test_performance.py
@@ -1,5 +1,6 @@
 """Performance tests"""
 import time
+import pytest
 
 def test_basic_performance(benchmark):
     """Basic performance test"""
@@ -17,3 +18,11 @@ def test_suricata_performance_placeholder(benchmark):
     
     result = benchmark(mock_operation)
     assert result["status"] == "success"
+
+@pytest.mark.performance
+def test_import_performance():
+    """Verify import performance meets targets."""
+    start = time.time()
+    import PLATFORM.core.scanner
+    duration = time.time() - start
+    assert duration < 0.5, f"Import took {duration}s, exceeds 500ms target"

--- a/tests/unit_tests/test_basic.py
+++ b/tests/unit_tests/test_basic.py
@@ -1,4 +1,6 @@
 """Basic unit tests"""
+from pathlib import Path
+
 def test_imports():
     """Test basic imports work"""
     import main
@@ -9,3 +11,8 @@ def test_imports():
 def test_placeholder():
     """Placeholder test"""
     assert 1 + 1 == 2
+
+def test_no_py_typed_files():
+    """Ensure no py.typed files exist in repository."""
+    py_typed_files = list(Path('.').rglob('py.typed'))
+    assert len(py_typed_files) == 0, f"Found py.typed files: {py_typed_files}"


### PR DESCRIPTION
This PR implements the test coverage recommendations from issue #67:

- Added `test_no_py_typed_files()` to verify no py.typed files exist in repository
- Added `test_import_performance()` to verify PLATFORM.core.scanner import meets 500ms target
- Both tests include clear assertion messages for debugging
- Proper integration with existing pytest markers and test structure

These tests will help prevent performance regressions and ensure repository cleanliness.

Closes #67

Generated with [Claude Code](https://claude.ai/code)