### PR TITLE
Fix memory leak in worker_health dictionary

### DIFF
--- a/PLATFORM/core/scanner.py
+++ b/PLATFORM/core/scanner.py
@@ -620,6 +620,10 @@ class MultiThreadScanner(BaseScanner):
 
             self.running = False
             
+            # Clean up worker_health dictionary to prevent memory leak
+            self.worker_health.clear()
+            self.logger.debug("Cleared worker_health dictionary")
+            
             # Calculate final uptime
             uptime = 0
             with self.performance_stats["lock"]:


### PR DESCRIPTION
Fixes potential memory leak in worker_health dictionary by clearing it during scanner shutdown.

Closes #88

Generated with [Claude Code](https://claude.ai/code)