### PR TITLE
Fix CI failures: resolve MagicMock comparison and circular import errors

### DIFF
--- a/tests/unit_tests/test_basic.py
+++ b/tests/unit_tests/test_basic.py
@@ -5,7 +5,16 @@ from pathlib import Path
 
 def test_imports():
     """Test basic imports work"""
-    import main
+    # Import from src directory to avoid circular import
+    import sys
+    from pathlib import Path
+    
+    # Add src to path
+    src_path = str(Path(__file__).parent.parent.parent / "src")
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+    
+    import main as src_main
     import setup_wizard
     import tutorial_system
 

--- a/tests/unit_tests/test_cleanup_manager.py
+++ b/tests/unit_tests/test_cleanup_manager.py
@@ -150,7 +150,7 @@ class TestFileCleanupManager(unittest.TestCase):
     def test_process_file_for_cleanup_old_unprocessed(self, mock_time):
         """Test processing an old unprocessed file for cleanup"""
         # Mock current time to make file appear old
-        current_time = time.time()
+        current_time = 1234567890.0  # Fixed timestamp for consistent testing
         mock_time.return_value = current_time
 
         # Create test file and make it old
@@ -177,7 +177,7 @@ class TestFileCleanupManager(unittest.TestCase):
     @patch("PLATFORM.core.cleanup_manager.time.time")
     def test_process_file_for_cleanup_old_matched(self, mock_time):
         """Test processing an old matched file for cleanup"""
-        current_time = time.time()
+        current_time = 1234567890.0  # Fixed timestamp for consistent testing
         mock_time.return_value = current_time
 
         test_file = self.extract_dir / "matched_file.txt"
@@ -208,7 +208,7 @@ class TestFileCleanupManager(unittest.TestCase):
     @patch("PLATFORM.core.cleanup_manager.time.time")
     def test_process_file_for_cleanup_old_clean(self, mock_time):
         """Test processing an old clean file for cleanup"""
-        current_time = time.time()
+        current_time = 1234567890.0  # Fixed timestamp for consistent testing
         mock_time.return_value = current_time
 
         test_file = self.extract_dir / "clean_file.txt"
@@ -236,7 +236,7 @@ class TestFileCleanupManager(unittest.TestCase):
     @patch("PLATFORM.core.cleanup_manager.time.time")
     def test_process_file_for_cleanup_recent_file(self, mock_time):
         """Test processing a recent file that should not be cleaned up"""
-        current_time = time.time()
+        current_time = 1234567890.0  # Fixed timestamp for consistent testing
         mock_time.return_value = current_time
 
         test_file = self.extract_dir / "recent_file.txt"
@@ -369,7 +369,7 @@ class TestFileCleanupManager(unittest.TestCase):
     @patch("PLATFORM.core.cleanup_manager.time.time")
     def test_cleanup_processed_files_success(self, mock_time):
         """Test successful cleanup operation"""
-        current_time = time.time()
+        current_time = 1234567890.0  # Fixed timestamp for consistent testing
         mock_time.return_value = current_time
 
         # Create old test files


### PR DESCRIPTION
Fixes #124

## Summary
Resolved CI test failures in cleanup manager tests and basic import tests:

- Fixed MagicMock comparison errors by using fixed timestamps in time.time() mocks
- Resolved circular import in test_basic.py by importing from src directory directly

## Changes
- `tests/unit_tests/test_cleanup_manager.py`: Fixed all time-dependent tests to use consistent numeric timestamps
- `tests/unit_tests/test_basic.py`: Updated import strategy to avoid circular dependency

Generated with [Claude Code](https://claude.ai/code)